### PR TITLE
Add lower python version constraint, switch to use pytest

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "highspy" %}
 {% set version = "1.7.2" %}
+{% set python_min = "3.8" %}
 
 package:
   name: {{ name|lower }}
@@ -34,7 +35,7 @@ requirements:
     - numpy
     - pybind11
   run:
-    - python
+    - python >={{ python_min }}
     - numpy
 
 test:
@@ -43,9 +44,10 @@ test:
   imports:
     - highspy
   commands:
-    - python -m unittest tests/test_highspy.py
+    - python -m pytest tests/test_highspy.py
   requires:
     - pip
+    - pytest
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - numpy
     - pybind11
   run:
-    - python >=3.8
+    - python
     - numpy
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "highspy" %}
 {% set version = "1.7.2" %}
-{% set python_min = "3.8" %}
 
 package:
   name: {{ name|lower }}
@@ -35,7 +34,7 @@ requirements:
     - numpy
     - pybind11
   run:
-    - python >={{ python_min }}
+    - python >=3.8
     - numpy
 
 test:


### PR DESCRIPTION
I have added python 3.8 as the lower limit for python versions. I also switched to using pytest instead of unittest, as it is listed as a development dependency in the pyproject.toml file of the original highs repository.

https://github.com/ERGO-Code/HiGHS/blob/master/pyproject.toml